### PR TITLE
Expose Color components.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,35 @@ impl Color {
         ((g as u32) << G32_SHIFT) |
         ((b as u32) << B32_SHIFT) }
     }
+
+    /// Get the alpha component.
+    pub fn a(self) -> u8 {
+        (self.val >> A32_SHIFT & 0xFF) as u8
+    }
+
+    /// Get the red component.
+    pub fn r(self) -> u8 {
+        (self.val >> R32_SHIFT & 0xFF) as u8
+    }
+
+    /// Get the green component.
+    pub fn g(self) -> u8 {
+        (self.val >> G32_SHIFT & 0xFF) as u8
+    }
+
+    /// Get the blue component.
+    pub fn b(self) -> u8 {
+        (self.val >> B32_SHIFT & 0xFF) as u8
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_color_argb() {
+    assert_eq!(Color::new(1, 2, 3, 4).a(), 1);
+    assert_eq!(Color::new(1, 2, 3, 4).r(), 2);
+    assert_eq!(Color::new(1, 2, 3, 4).g(), 3);
+    assert_eq!(Color::new(1, 2, 3, 4).b(), 4);
 }
 
 #[derive(Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,7 @@ pub fn muldiv255(a: u32, b: u32) -> u32 {
     /* The deriviation for this formula can be
      * found in "Three Wrongs Make a Right" by Jim Blinn.*/
     let tmp = a * b + 128;
-    ((tmp + (tmp >> 8)) >> 8)
+    (tmp + (tmp >> 8)) >> 8
 }
 
 /** Calculates floor(a/255 + 0.5) */
@@ -675,7 +675,7 @@ pub fn div255(a: u32) -> u32 {
     /* The deriviation for this formula can be
      * found in "Three Wrongs Make a Right" by Jim Blinn.*/
     let tmp = a + 128;
-    ((tmp + (tmp >> 8)) >> 8)
+    (tmp + (tmp >> 8)) >> 8
 }
 
 #[inline]


### PR DESCRIPTION
This PR exposes the components of the ARGB color through methods. It's quite useful to be able to extract these again.

One obvious bikeshed: should they be called `a()`, `r()`, `g()` and `b()` or `alpha()`, `red()`, `green()` and `blue()`?

I went for the one-letter versions now because they are more terse, and you will often end up doing something like `foo(color.r(), color.g(), color.b())`, so terseness is nice. But I could rename them.