### PR TITLE
add `no_std` compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ documentation = "https://docs.rs/sw-composite"
 repository = "https://github.com/jrmuizel/sw-composite/"
 
 [dependencies]
+num-traits = { version = "0.2.17", default-features = false, features = ["libm"] }
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
I have an interest in making the `raqote` crate `no_std` compatible, which involves also making this crate `no_std` compatible.

All I've done is swapped out any `std` imports with their corresponding `alloc` and `core` imports, added a dependency on `num_traits` to provide floating point and trig operations for `no_std`, and made a new default feature for `std` to avoid breaking changes.

Let me know if there's anything I should fix, thanks!